### PR TITLE
Fix table format

### DIFF
--- a/instructions.mbd
+++ b/instructions.mbd
@@ -34,25 +34,25 @@ Update the `progress.md` in your folder periodically, at least once every two we
 <tabs>
   <tab header="Sample">
 
-Week | Achievements
----- | ------------
-1 | Reviewed PR: [PR name 1 #1234]()
-1 | Merged PR: [PR name 4 #3245]()
-2 | Submitted Issue: [Issue name #223]()
-2 | Authored PR (put on hold by request): [PR name 3 #365]()
-2 | Responded to contributor queries: [#1234](), [#4567]()
+| Week | Achievements |
+| ---- | ------------ |
+| 1 | Reviewed PR: [PR name 1 #1234]() |
+| 1 | Merged PR: [PR name 4 #3245]() |
+| 2 | Submitted Issue: [Issue name #223]() |
+| 2 | Authored PR (put on hold by request): [PR name 3 #365]() |
+| 2 | Responded to contributor queries: [#1234](), [#4567]() |
 
   </tab>
   <tab header="Code for the sample">
 
 ```
-Week | Achievements
----- | ------------
-1 | Reviewed PR: [PR name 1 #1234]()
-1 | Merged PR: [PR name 4 #3245]()
-2 | Submitted Issue: [Issue name #223]()
-2 | Authored PR (put on hold by request): [PR name 3 #365]()
-2 | Responded to contributor queries: [#1234](), [#4567]()
+| Week | Achievements |
+| ---- | ------------ |
+| 1 | Reviewed PR: [PR name 1 #1234]() |
+| 1 | Merged PR: [PR name 4 #3245]() |
+| 2 | Submitted Issue: [Issue name #223]() |
+| 2 | Authored PR (put on hold by request): [PR name 3 #365]() |
+| 2 | Responded to contributor queries: [#1234](), [#4567]() |
 ```
 </tab>
 </tabs>


### PR DESCRIPTION
Proposed commit message:
```
IntelliJ shows a compatibility warning for the progress report table
saying that all rows should have pipe borders at the start and end.

Let's change the given progress report template so that students
need not manually add in the pipe borders after copy-pasting.
```